### PR TITLE
Testing the Windows path resolve

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+build:
+  verbosity: minimal
+
+environment:
+  nodejs_version: "7.0"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn install
+
+test_script:
+  - node --version
+  - yarn --version
+  # run tests
+  - yarn test
+
+cache:
+ - node_modules
+ - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,19 @@
-build:
-  verbosity: minimal
-
 environment:
-  nodejs_version: "7.0"
-
+  matrix:
+    - nodejs_version: '7'
+    - nodejs_version: '4'
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
 install:
   - ps: Install-Product node $env:nodejs_version
+  - set CI=true
   - yarn install
-
 test_script:
-  - node --version
-  - yarn --version
-  # run tests
   - yarn test
-
 cache:
  - node_modules
  - "%LOCALAPPDATA%\\Yarn"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:cdaringe/parse-yarn-lock.git",
   "author": "cdaringe",
   "license": "MIT",
+  "scripts": {
+    "test": "node ./test/index.js"
+  },
   "dependencies": {
     "run-waterfall": "^1.1.3",
     "tape": "^4.6.3",

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,13 @@ module.exports = {
     })
   },
   getGlobalYarnParser: function(yarnPath, cb) {
+    console.log('yarnPath', yarnPath);
     // <yarn>/bin/yarn ==> (src) <yarn>/src/lockfile
     //                     (compiled) <yar>lib/node_modules/yarn/lib/lockfile/parse.js
-    var parser = require(path.resolve(yarnPath, '../../lib/lockfile/parse.js'))
+    var parserPath = path.resolve(yarnPath, '../../lib/lockfile/parse.js')
+    console.log('parserPath', parserPath)
+    var parser = require(parserPath)
+    console.log('parser', parser);
     return cb(null, parser.default)
   }
 }


### PR DESCRIPTION
I'm [seeing errors](https://github.com/devtools-html/devtools-core/pull/280) with the appveyor windows tests which look like the [`path.resolve`](https://github.com/cdaringe/parse-yarn-lock/blob/master/src/index.js#L25   ) call isn't working 